### PR TITLE
Create allow-pr-only-from-epic-branches.yml

### DIFF
--- a/.github/workflows/allow-pr-only-from-epic-branches.yml
+++ b/.github/workflows/allow-pr-only-from-epic-branches.yml
@@ -1,0 +1,17 @@
+name: Only allow pull requests to merge from epic branches
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-branch-name:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch name
+        run: |
+          if [[ ! ${{ github.head_ref }} =~ epic/* ]]; then
+            echo "Branch name does not match the required pattern."
+            exit 1
+          fi


### PR DESCRIPTION
Workflow to allow merges into main only when the source branch is epic/*