### PR TITLE
Epic/allow prs into main only from epic branches

### DIFF
--- a/.github/workflows/allow-pr-only-from-epic-branches.yml
+++ b/.github/workflows/allow-pr-only-from-epic-branches.yml
@@ -1,0 +1,17 @@
+name: Only allow pull requests to merge from epic branches
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-branch-name:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch name
+        run: |
+          if [[ ! ${{ github.head_ref }} =~ epic/* ]]; then
+            echo "Branch name does not match the required pattern."
+            exit 1
+          fi

--- a/.github/workflows/allow-pr-only-from-epic-branches.yml
+++ b/.github/workflows/allow-pr-only-from-epic-branches.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check-branch-name:
     runs-on: ubuntu-latest

--- a/.github/workflows/allow-pr-only-from-epic-branches.yml
+++ b/.github/workflows/allow-pr-only-from-epic-branches.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Check branch name
         run: |
-          if [[ ! ${{ github.head_ref }} =~ epic/* ]]; then
+          if [[ ! ${{ github.head_ref }} =~ ^epic/.* ]]; then
             echo "Branch name does not match the required pattern."
             exit 1
           fi


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that restricts pull requests to the main branch so that they can only be merged from branches whose names follow the "epic/*" pattern.

-    Introduces a workflow file to enforce branch naming.
-    Implements a branch name check to prevent non-epic branches from being merged into main.